### PR TITLE
Add packages

### DIFF
--- a/ports/gstreamer-rockchip/portfile.cmake
+++ b/ports/gstreamer-rockchip/portfile.cmake
@@ -1,0 +1,26 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO JeffyCN/rockchip_mirrors
+    REF gstreamer-rockchip
+    SHA512 e1cbfb9b02132dbc7a22ee88606a85ca76e30058da97c41bb493363cbbea4eafb77295bdbc73bec6e60b483124ad64d4059bf79fb54191b897b89ad29f2cd55d
+)
+
+# set(OUT_FEATURE_OPTIONS "")
+# vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURES)
+
+# Set up environment variables for building
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I${SOURCE_PATH}/include")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L${SOURCE_PATH}/lib")
+
+
+# Configure, build, and install using Meson
+vcpkg_configure_meson(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        --prefix=${CURRENT_PACKAGES_DIR}
+)
+
+vcpkg_install_meson()
+
+# Remove unnecessary files (if necessary)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/share)

--- a/ports/gstreamer-rockchip/vcpkg.json
+++ b/ports/gstreamer-rockchip/vcpkg.json
@@ -1,0 +1,10 @@
+{
+    "name": "gstreamer-rockchip",
+    "version-string": "1.0.0",
+    "description": "GStreamer plugin for Rockchip platform.",
+    "homepage": "https://github.com/rockchip-linux/gstreamer-rockchip",
+    "dependencies": [
+        "gstreamer",
+        "glib"
+    ]
+}

--- a/ports/onnxruntime-custom/portfile.cmake
+++ b/ports/onnxruntime-custom/portfile.cmake
@@ -1,0 +1,45 @@
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/anaph/onnxruntime/releases/download/v${VERSION}/onnxruntime-linux-${VCPKG_TARGET_ARCHITECTURE}${VCPKG_TARGET_FEATURE}-${VERSION}.tar.gz"
+    FILENAME "onnxruntime-linux-${VCPKG_TARGET_ARCHITECTURE}${VCPKG_TARGET_FEATURE}-${VERSION}.tar.gz"
+    SKIP_SHA512 TRUE
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    NO_REMOVE_ONE_LEVEL
+)
+
+set(ONNX_LIB_PATH "onnxruntime-linux-${VCPKG_TARGET_ARCHITECTURE}${VCPKG_TARGET_FEATURE}/onnxruntime-linux-${VCPKG_TARGET_ARCHITECTURE}${VCPKG_TARGET_FEATURE}")
+
+file(MAKE_DIRECTORY
+        ${CURRENT_PACKAGES_DIR}/include
+        ${CURRENT_PACKAGES_DIR}/lib
+        ${CURRENT_PACKAGES_DIR}/bin
+        ${CURRENT_PACKAGES_DIR}/debug/lib
+        ${CURRENT_PACKAGES_DIR}/debug/bin
+    )
+
+file(COPY
+        ${SOURCE_PATH}/${ONNX_LIB_PATH}/include/onnxruntime
+        DESTINATION ${CURRENT_PACKAGES_DIR}
+    )
+
+file(COPY ${SOURCE_PATH}/${ONNX_LIB_PATH}/lib/libonnxruntime.so
+    DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+file(COPY ${SOURCE_PATH}/${ONNX_LIB_PATH}/lib/libonnxruntime.so
+    DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
+
+file(COPY ${SOURCE_PATH}/${ONNX_LIB_PATH}/lib/libonnxruntime.so.${VERSION}
+    DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
+file(COPY ${SOURCE_PATH}/${ONNX_LIB_PATH}/lib/libonnxruntime.so.${VERSION}
+    DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
+
+
+file(COPY ${SOURCE_PATH}/${ONNX_LIB_PATH}/lib/onnxruntime_providers_shared.so
+    DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
+file(COPY ${SOURCE_PATH}/${ONNX_LIB_PATH}/lib/onnxruntime_providers_shared.so
+    DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
+

--- a/ports/onnxruntime-custom/vcpkg.json
+++ b/ports/onnxruntime-custom/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "onnxruntime-custom",
+  "version": "1.17.3-custom",
+  "description": "onnxruntime (custom)",
+  "homepage": "https://github.com/microsoft/onnxruntime",
+  "license": "MIT"
+}

--- a/ports/onnxruntime/onnxruntimeConfig.cmake
+++ b/ports/onnxruntime/onnxruntimeConfig.cmake
@@ -1,0 +1,34 @@
+# Custom cmake config file by jcarius to enable find_package(onnxruntime) without modifying LIBRARY_PATH and LD_LIBRARY_PATH
+# Place file at ~/.local/share/cmake/onnxruntime
+# This will define the following variables:
+#   onnxruntime_FOUND        -- True if the system has the onnxruntime library
+#   onnxruntime_INCLUDE_DIRS -- The include directories for onnxruntime
+#   onnxruntime_LIBRARIES    -- Libraries to link against
+#   onnxruntime_CXX_FLAGS    -- Additional (required) compiler flags
+
+include(FindPackageHandleStandardArgs)
+
+# Assume we are in <install-prefix>/share/cmake/onnxruntime/onnxruntimeConfig.cmake
+get_filename_component(CMAKE_CURRENT_LIST_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+get_filename_component(onnxruntime_INSTALL_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../../" ABSOLUTE)
+
+message(${onnxruntime_INSTALL_PREFIX})
+
+set(onnxruntime_INCLUDE_DIRS ${onnxruntime_INSTALL_PREFIX}/include)
+set(onnxruntime_LIBRARIES onnxruntime)
+set(onnxruntime_CXX_FLAGS "") # no flags needed
+
+#find_library(onnxruntime_LIBRARY libonnxruntime.so
+    #HINTS ${onnxruntime_INSTALL_PREFIX}/lib
+#)
+
+set(onnxruntime_LIBRARY ${onnxruntime_INSTALL_PREFIX}/bin/libonnxruntime.so.1.17.3)
+
+message(${onnxruntime_LIBRARY})
+
+add_library(onnxruntime SHARED IMPORTED)
+set_property(TARGET onnxruntime PROPERTY IMPORTED_LOCATION "${onnxruntime_LIBRARY}")
+set_property(TARGET onnxruntime PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${onnxruntime_INCLUDE_DIRS}")
+set_property(TARGET onnxruntime PROPERTY INTERFACE_COMPILE_OPTIONS "${onnxruntime_CXX_FLAGS}")
+
+find_package_handle_standard_args(onnxruntime DEFAULT_MSG onnxruntime_LIBRARY onnxruntime_INCLUDE_DIRS)

--- a/ports/onnxruntime/onnxruntimeVersion.cmake
+++ b/ports/onnxruntime/onnxruntimeVersion.cmake
@@ -1,0 +1,13 @@
+# Custom cmake version file by jcarius, place at ~/.local/share/cmake/onnxruntime
+
+set(PACKAGE_VERSION "1.7.3")
+
+# Check whether the requested PACKAGE_FIND_VERSION is compatible
+if("${PACKAGE_VERSION}" VERSION_LESS "${PACKAGE_FIND_VERSION}")
+  set(PACKAGE_VERSION_COMPATIBLE FALSE)
+else()
+  set(PACKAGE_VERSION_COMPATIBLE TRUE)
+  if("${PACKAGE_VERSION}" VERSION_EQUAL "${PACKAGE_FIND_VERSION}")
+    set(PACKAGE_VERSION_EXACT TRUE)
+  endif()
+endif()

--- a/ports/onnxruntime/portfile.cmake
+++ b/ports/onnxruntime/portfile.cmake
@@ -1,0 +1,58 @@
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/microsoft/onnxruntime/releases/download/v${VERSION}/onnxruntime-linux-${VCPKG_TARGET_ARCHITECTURE}-${VERSION}.tgz"
+    FILENAME "onnxruntime-linux-${VCPKG_TARGET_ARCHITECTURE}-${VERSION}.tgz"
+    SKIP_SHA512 TRUE
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    NO_REMOVE_ONE_LEVEL
+)
+
+set(onnxruntime_DIR ${CURRENT_PACKAGES_DIR}/share/onnxruntime)
+set(ONNX_LIB_PATH onnxruntime-linux-${VCPKG_TARGET_ARCHITECTURE}${VCPKG_TARGET_FEATURE}-${VERSION})
+
+
+file(MAKE_DIRECTORY
+        ${CURRENT_PACKAGES_DIR}/include
+        ${CURRENT_PACKAGES_DIR}/lib
+        ${CURRENT_PACKAGES_DIR}/bin
+        ${CURRENT_PACKAGES_DIR}/debug/lib
+        ${CURRENT_PACKAGES_DIR}/debug/bin
+        ${CURRENT_PACKAGES_DIR}/share/onnxruntime
+    )
+
+file(COPY
+    ${SOURCE_PATH}/${ONNX_LIB_PATH}/include
+    DESTINATION ${CURRENT_PACKAGES_DIR}
+)
+
+
+get_filename_component(CMAKE_CURRENT_LIST_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+file(COPY
+    ${CMAKE_CURRENT_LIST_DIR}/onnxruntimeVersion.cmake
+    DESTINATION ${CURRENT_PACKAGES_DIR}/share/onnxruntime
+)
+
+file(COPY
+    ${CMAKE_CURRENT_LIST_DIR}/onnxruntimeConfig.cmake
+    DESTINATION ${CURRENT_PACKAGES_DIR}/share/onnxruntime
+)
+
+file(COPY ${SOURCE_PATH}/${ONNX_LIB_PATH}/lib/libonnxruntime.so
+    DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+file(COPY ${SOURCE_PATH}/${ONNX_LIB_PATH}/lib/libonnxruntime.so
+    DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
+
+file(COPY ${SOURCE_PATH}/${ONNX_LIB_PATH}/lib/libonnxruntime.so.${VERSION}
+    DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
+file(COPY ${SOURCE_PATH}/${ONNX_LIB_PATH}/lib/libonnxruntime.so.${VERSION}
+    DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
+
+
+
+# # Handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/${ONNX_LIB_PATH}/LICENSE")

--- a/ports/onnxruntime/vcpkg.json
+++ b/ports/onnxruntime/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "onnxruntime",
+  "version": "1.17.3",
+  "description": "onnxruntime",
+  "homepage": "https://github.com/microsoft/onnxruntime",
+  "license": "MIT"
+}

--- a/ports/rknpu/portfile.cmake
+++ b/ports/rknpu/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_download_distfile(
+    RKNPU
+    URLS "https://github.com/rockchip-linux/rknpu/archive/refs/tags/v1.7.3.zip"
+    FILENAME "rknpu-1.7.3.zip"
+    SHA512 SHA512 d72f3616a05166368e3642cb2a3a42227c7d9e0eba994ce58691d9711fef51172783b8439a1d88187f5cbb4889de1210341890db72bc97ef5ee67e39659e88f5
+)
+
+# Extract the downloaded archive
+vcpkg_extract_source_archive(
+    OUT_SOURCE_PATH 
+    ARCHIVE ${DOWNLOADS}/rknpu-1.7.3.zip
+)
+
+# Install the necessary headers, libraries, and executables
+file(GLOB HEADER_FILES "${OUT_SOURCE_PATH}/rknn/include/*.h")
+file(COPY ${HEADER_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/include/rknn)
+file(GLOB BINARY_FILES "${OUT_SOURCE_PATH}/drivers/linux-armhf-puma/usr/bin/*")
+file(COPY ${BINARY_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/bin/rknn)
+file(GLOB LIBRARY_FILES "${OUT_SOURCE_PATH}/drivers/linux-armhf-puma/usr/lib/*")
+file(COPY ${LIBRARY_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/lib/rknn)
+# Install documentation
+file(INSTALL "${OUT_SOURCE_PATH}/rknn/doc" DESTINATION ${CURRENT_PACKAGES_DIR}/share/rknn)
+
+# Clean up unnecessary files
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/share/rknpu/.git)

--- a/ports/rknpu/vcpkg.json
+++ b/ports/rknpu/vcpkg.json
@@ -1,0 +1,7 @@
+{
+    "name": "rknpu",
+    "version-string": "1.7.3",
+    "description": "Rockchip Neural Processing Unit (NPU) library and drivers.",
+    "homepage": "https://github.com/rockchip-linux/rknpu",
+    "dependencies": []
+}


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
